### PR TITLE
PydanticTwoCompatibility: Handle missing __validators__

### DIFF
--- a/vectordb/utils/create_doc_type.py
+++ b/vectordb/utils/create_doc_type.py
@@ -15,7 +15,8 @@ def create_output_doc_type(input_doc_type: Type['BaseDoc']):
     return create_model(
         input_doc_type.__name__ + 'WithMatchesAndScores',
         __base__=input_doc_type,
-        __validators__=input_doc_type.__validators__,
+        # NOTE: With pydantic>=2, __validators__ does not exist
+        __validators__=getattr(input_doc_type, "__validators__", None),
         matches=(DocList[input_doc_type], []),
         scores=(List[float], [])
     )


### PR DESCRIPTION
https://github.com/jina-ai/vectordb/issues/67

<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

This PR is a partial fix to #67 to allow `create_output_doc_type` to work with `pydantic>=2`. It does not address the transitive dependency from `jina` which would require further investigation.